### PR TITLE
use existing g5 auth user on create

### DIFF
--- a/lib/devise_g5_authenticatable/g5/auth_user_creator.rb
+++ b/lib/devise_g5_authenticatable/g5/auth_user_creator.rb
@@ -15,9 +15,19 @@ module Devise
 
       private
       def create_auth_user
-        auth_user = auth_client.create_user(auth_user_args)
         set_auth_attributes(auth_user)
-        auth_user
+      end
+
+      def auth_user
+        begin
+          auth_client.create_user(auth_user_args)
+        rescue  StandardError => e
+          if e.message =~ /Email has already been taken/
+            auth_client.find_user_by_email(model.email)
+          else
+            raise e
+          end
+        end
       end
 
       def auth_user_exists?
@@ -42,6 +52,7 @@ module Devise
         model.provider = 'g5'
         model.uid = auth_user.id
         model.clean_up_passwords
+        model
       end
     end
   end

--- a/spec/g5/auth_user_creator_spec.rb
+++ b/spec/g5/auth_user_creator_spec.rb
@@ -16,84 +16,104 @@ describe Devise::G5::AuthUserCreator do
     let(:password) { 'new password' }
     let(:password_confirmation) { 'new password confirmation' }
 
-    let(:auth_client) { double(:g5_authentication_client, create_user: auth_user) }
-    let(:auth_user) { double(:auth_user, id: uid, email: model.email) }
+    let(:auth_client) { double(:g5_authentication_client) }
+    let(:auth_user) { double(:auth_user, id: uid, email: model.email, clean_up_passwords: nil) }
     let(:uid) { 'remote-auth-user-42' }
+
     before do
       allow(G5AuthenticationClient::Client).to receive(:new).and_return(auth_client)
     end
 
-    context 'when the new model has no uid' do
-      before { model.uid = nil }
-
-      context 'when updated by an existing user' do
-        let(:updated_by) { build_stubbed(:user) }
-
-        before { create }
-
-        it 'should use the token for updated_by user to call g5 auth' do
-          expect(G5AuthenticationClient::Client).to have_received(:new).
-            with(access_token: updated_by.g5_access_token)
-        end
-
-        it 'should create a new auth user with the correct email' do
-          expect(auth_client).to have_received(:create_user).
-            with(hash_including(email: model.email))
-        end
-
-        it 'should create a new auth user with the correct password' do
-          expect(auth_client).to have_received(:create_user).
-            with(hash_including(password: password))
-        end
-
-        it 'should create a new auth user with the correct password confirmation' do
-          expect(auth_client).to have_received(:create_user).
-            with(hash_including(password_confirmation: password_confirmation))
-        end
-
-        it 'should reset the password' do
-          expect(model.password).to be_nil
-        end
-
-        it 'should reset the password_confirmation' do
-          expect(model.password_confirmation).to be_nil
-        end
+    context 'when there is an existing auth user' do
+      before do
+        model.uid = nil
+        allow(auth_client).to receive(:create_user).and_raise(StandardError.new('Email has already been taken'))
+        allow(auth_client).to receive(:find_user_by_email).and_return(auth_user)
+        create
       end
 
-      context 'when auth service returns an error' do
-        before do
-          allow(auth_client).to receive(:create_user).and_raise('Error!')
-        end
-
-        it 'should raise an exception' do
-          expect { create }.to raise_error('Error!')
-        end
-      end
-
-      context 'when not updated by an existing user' do
-        before { create }
-
-        it 'should use the user token to call g5 auth' do
-          expect(G5AuthenticationClient::Client).to have_received(:new).
-            with(access_token: model.g5_access_token)
-        end
+      it 'should create the local user with the existing uid' do
+        expect(model.uid).to eq(uid)
       end
     end
 
-    context 'when new model already has a uid' do
-      before { model.uid = 'remote-user-42' }
-      before { create }
-
-      it 'should not create a user' do
-        expect(auth_client).to_not have_received(:create_user)
+    context 'when there is no existing auth user' do
+      before do
+        allow(auth_client).to receive(:create_user).and_return(auth_user)
       end
 
-      it 'should not reset the password' do
-        expect(model.password).to_not be_blank
+      context 'when the new model has no uid' do
+        before { model.uid = nil }
+
+        context 'when updated by an existing user' do
+          let(:updated_by) { build_stubbed(:user) }
+
+          before { create }
+
+          it 'should use the token for updated_by user to call g5 auth' do
+            expect(G5AuthenticationClient::Client).to have_received(:new).
+              with(access_token: updated_by.g5_access_token)
+          end
+
+          it 'should create a new auth user with the correct email' do
+            expect(auth_client).to have_received(:create_user).
+              with(hash_including(email: model.email))
+          end
+
+          it 'should create a new auth user with the correct password' do
+            expect(auth_client).to have_received(:create_user).
+              with(hash_including(password: password))
+          end
+
+          it 'should create a new auth user with the correct password confirmation' do
+            expect(auth_client).to have_received(:create_user).
+              with(hash_including(password_confirmation: password_confirmation))
+          end
+
+          it 'should reset the password' do
+            expect(model.password).to be_nil
+          end
+
+          it 'should reset the password_confirmation' do
+            expect(model.password_confirmation).to be_nil
+          end
+        end
+
+        context 'when auth service returns an error' do
+          before do
+            allow(auth_client).to receive(:create_user).and_raise('Error!')
+          end
+
+          it 'should raise an exception' do
+            expect { create }.to raise_error('Error!')
+          end
+        end
+
+        context 'when not updated by an existing user' do
+          before { create }
+
+          it 'should use the user token to call g5 auth' do
+            expect(G5AuthenticationClient::Client).to have_received(:new).
+              with(access_token: model.g5_access_token)
+          end
+        end
       end
 
-      it 'should not reset the password_confirmation' do
-        expect(model.password_confirmation).to_not be_blank
+      context 'when new model already has a uid' do
+        before { model.uid = 'remote-user-42' }
+        before { create }
+
+        it 'should not create a user' do
+          expect(auth_client).to_not have_received(:create_user)
+        end
+
+        it 'should not reset the password' do
+          expect(model.password).to_not be_blank
+        end
+
+        it 'should not reset the password_confirmation' do
+          expect(model.password_confirmation).to_not be_blank
+        end
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,4 +41,6 @@ RSpec.configure do |config|
   # config.filter_run_excluding type: 'feature'
 
   config.after(:suite) { WebMock.disable! }
+
+  config.infer_spec_type_from_file_location!
 end


### PR DESCRIPTION
Find user by email on duplicate  email error on create https://www.pivotaltracker.com/story/show/74974008
