### PR TITLE
Token validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ environment variables for your client application:
 
 ### Configuration
 
-In `config/initializers/devise.rb`, add the following:
+In `config/initializers/devise.rb`, add the following to enable authentication:
 
 ```ruby
 Devise.setup do |config|
@@ -181,6 +181,29 @@ will need to insert the following in your `config/initializers/devise.rb`:
 ```ruby
 require 'devise_g5_authenticatable/models/protected_attributes'
 ```
+
+### Token validation
+
+After a user authenticates, their access token will be stored on the G5
+Authenticatable model. By default, this token will not be validated against
+the auth server again until the local session is destroyed, either because
+it times out, or because the user explicitly logs out of the local application.
+
+In order to implement single sign-out, you can enable strict token validation.
+This will validate the token against the auth server on every request, and
+automatically destroy the local session if the token is no longer valid.
+
+In your `config/initializers/devise.rb':
+
+```ruby
+Devise.setup do |config|
+  # ...
+  config.g5_strict_token_validation = true
+end
+```
+
+Note that strict token validation incurs a non-trivial amount of performance
+overhead, which is why it is disabled by default.
 
 ## Examples
 

--- a/lib/devise_g5_authenticatable.rb
+++ b/lib/devise_g5_authenticatable.rb
@@ -9,6 +9,14 @@ require 'devise_g5_authenticatable/controllers/url_helpers'
 
 require 'devise_g5_authenticatable/engine'
 
+module Devise
+  # Should devise_g5_authenticatable validate the user's access token
+  # against the auth server for every request? Default is false
+  @@g5_strict_token_validation = false
+
+  mattr_accessor :g5_strict_token_validation
+end
+
 Devise.add_module(:g5_authenticatable,
                   strategy: false,
                   route: {session: [nil, :new, :destroy]},

--- a/lib/devise_g5_authenticatable/hooks/g5_authenticatable.rb
+++ b/lib/devise_g5_authenticatable/hooks/g5_authenticatable.rb
@@ -9,6 +9,7 @@ Warden::Manager.after_set_user only: :fetch do |record, warden, options|
     rescue StandardError => error
       proxy = Devise::Hooks::Proxy.new(warden)
       proxy.sign_out(record)
+      record.revoke_g5_credentials!
       throw :warden, scope: scope
     end
   end

--- a/lib/devise_g5_authenticatable/hooks/g5_authenticatable.rb
+++ b/lib/devise_g5_authenticatable/hooks/g5_authenticatable.rb
@@ -1,0 +1,13 @@
+Warden::Manager.after_set_user only: :fetch do |record, warden, options|
+  scope = options[:scope]
+
+  auth_client = G5AuthenticationClient::Client.new(allow_password_credentials: 'false',
+                                                   access_token: record.g5_access_token)
+  begin
+    auth_client.token_info
+  rescue StandardError => error
+    proxy = Devise::Hooks::Proxy.new(warden)
+    proxy.sign_out(record)
+    throw :warden, scope: scope
+  end
+end

--- a/lib/devise_g5_authenticatable/hooks/g5_authenticatable.rb
+++ b/lib/devise_g5_authenticatable/hooks/g5_authenticatable.rb
@@ -1,13 +1,15 @@
 Warden::Manager.after_set_user only: :fetch do |record, warden, options|
-  scope = options[:scope]
+  if Devise.g5_strict_token_validation
+    scope = options[:scope]
 
-  auth_client = G5AuthenticationClient::Client.new(allow_password_credentials: 'false',
-                                                   access_token: record.g5_access_token)
-  begin
-    auth_client.token_info
-  rescue StandardError => error
-    proxy = Devise::Hooks::Proxy.new(warden)
-    proxy.sign_out(record)
-    throw :warden, scope: scope
+    auth_client = G5AuthenticationClient::Client.new(allow_password_credentials: 'false',
+                                                     access_token: record.g5_access_token)
+    begin
+      auth_client.token_info
+    rescue StandardError => error
+      proxy = Devise::Hooks::Proxy.new(warden)
+      proxy.sign_out(record)
+      throw :warden, scope: scope
+    end
   end
 end

--- a/lib/devise_g5_authenticatable/models/g5_authenticatable.rb
+++ b/lib/devise_g5_authenticatable/models/g5_authenticatable.rb
@@ -1,4 +1,5 @@
 require 'devise_g5_authenticatable/g5'
+require 'devise_g5_authenticatable/hooks/g5_authenticatable'
 
 module Devise
   module Models

--- a/spec/features/token_validation_spec.rb
+++ b/spec/features/token_validation_spec.rb
@@ -1,0 +1,61 @@
+require 'spec_helper'
+
+describe 'Token validation per request' do
+  let(:user) { create(:user) }
+  let(:protected_path) { edit_user_registration_path }
+  let(:token_info_url) { 'http://auth.g5search.com/oauth/token/info' }
+
+  before do
+    stub_request(:get, token_info_url).
+      with(headers: {'Authorization'=>"Bearer #{user.g5_access_token}"}).
+      to_return(status: 200, body: '', headers: {})
+  end
+
+  before do
+    visit_path_and_login_with(protected_path, user)
+
+    # Now that we're logged in, any subsequent attempts to
+    # authenticate with the auth server will trigger an omniauth
+    # failure, which is a condition we can test for
+    stub_g5_invalid_credentials
+  end
+
+  context 'when the access_token is valid' do
+    it 'should validate the token against the auth server' do
+      expect(a_request(:get, token_info_url).
+             with(headers: {'Authorization' => "Bearer #{user.g5_access_token}"})).to have_been_made
+    end
+
+    it 'should allow the user to access the protected page' do
+      expect(current_path).to eq(protected_path)
+    end
+  end
+
+  context 'when the access_token has been invalidated' do
+    before do
+      stub_request(:get, token_info_url).
+        with(headers: {'Authorization'=>"Bearer #{user.g5_access_token}"}).
+        to_return(status: 401,
+                  headers: {'Content-Type' => 'application/json; charset=utf-8',
+                            'Cache-Control' => 'no-cache'},
+                  body: {'error' => 'invalid_token',
+                         'error_description' => 'The access token expired'}.to_json)
+      visit protected_path
+    end
+
+    it 'should force the user to re-authenticate' do
+      expect(page).to have_content('Invalid credentials')
+    end
+  end
+
+  context 'when there is some other error from the auth server' do
+    before do
+      stub_request(:get, token_info_url).to_raise(StandardError)
+      visit protected_path
+    end
+
+    it 'should force the user to re-authenticate' do
+      expect(page).to have_content('Invalid credentials')
+    end
+  end
+end

--- a/spec/features/token_validation_spec.rb
+++ b/spec/features/token_validation_spec.rb
@@ -20,10 +20,14 @@ describe 'Token validation per request' do
     stub_g5_invalid_credentials
   end
 
-  context 'when the access_token is valid' do
-    it 'should validate the token against the auth server' do
-      expect(a_request(:get, token_info_url).
-             with(headers: {'Authorization' => "Bearer #{user.g5_access_token}"})).to have_been_made
+  context 'when token validation is disabled' do
+    before do
+      Devise.g5_strict_token_validation = false
+      visit protected_path
+    end
+
+    it 'should not valid the token against the auth server' do
+      expect(a_request(:get, token_info_url)).to_not have_been_made
     end
 
     it 'should allow the user to access the protected page' do
@@ -31,31 +35,48 @@ describe 'Token validation per request' do
     end
   end
 
-  context 'when the access_token has been invalidated' do
-    before do
-      stub_request(:get, token_info_url).
-        with(headers: {'Authorization'=>"Bearer #{user.g5_access_token}"}).
-        to_return(status: 401,
-                  headers: {'Content-Type' => 'application/json; charset=utf-8',
-                            'Cache-Control' => 'no-cache'},
-                  body: {'error' => 'invalid_token',
-                         'error_description' => 'The access token expired'}.to_json)
-      visit protected_path
+  context 'when token validation is enabled' do
+    before { Devise.g5_strict_token_validation = true }
+
+    context 'when the access_token is valid' do
+      before { visit protected_path }
+
+      it 'should validate the token against the auth server' do
+        expect(a_request(:get, token_info_url).
+               with(headers: {'Authorization' => "Bearer #{user.g5_access_token}"})).to have_been_made
+      end
+
+      it 'should allow the user to access the protected page' do
+        expect(current_path).to eq(protected_path)
+      end
     end
 
-    it 'should force the user to re-authenticate' do
-      expect(page).to have_content('Invalid credentials')
-    end
-  end
+    context 'when the access_token has been invalidated' do
+      before do
+        stub_request(:get, token_info_url).
+          with(headers: {'Authorization'=>"Bearer #{user.g5_access_token}"}).
+          to_return(status: 401,
+                    headers: {'Content-Type' => 'application/json; charset=utf-8',
+                              'Cache-Control' => 'no-cache'},
+                    body: {'error' => 'invalid_token',
+                           'error_description' => 'The access token expired'}.to_json)
+        visit protected_path
+      end
 
-  context 'when there is some other error from the auth server' do
-    before do
-      stub_request(:get, token_info_url).to_raise(StandardError)
-      visit protected_path
+      it 'should force the user to re-authenticate' do
+        expect(page).to have_content('Invalid credentials')
+      end
     end
 
-    it 'should force the user to re-authenticate' do
-      expect(page).to have_content('Invalid credentials')
+    context 'when there is some other error from the auth server' do
+      before do
+        stub_request(:get, token_info_url).to_raise(StandardError)
+        visit protected_path
+      end
+
+      it 'should force the user to re-authenticate' do
+        expect(page).to have_content('Invalid credentials')
+      end
     end
   end
 end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,3 +1,4 @@
 RSpec.configure do |config|
+  config.before(:each) { Devise.g5_strict_token_validation = false }
   config.include Devise::TestHelpers, type: :controller
 end

--- a/spec/support/user_feature_methods.rb
+++ b/spec/support/user_feature_methods.rb
@@ -19,7 +19,10 @@ module UserFeatureMethods
 end
 
 RSpec.configure do |config|
-  config.before(:each) { OmniAuth.config.test_mode = true }
+  config.before(:each) do
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:g5] = nil
+  end
   config.after(:each) { OmniAuth.config.test_mode = false }
 
   config.include UserFeatureMethods, type: :feature

--- a/spec/tasks/export_users_spec.rb
+++ b/spec/tasks/export_users_spec.rb
@@ -6,20 +6,30 @@ describe 'g5:export_users' do
   let(:user_exporter) { double(:user_exporter, export: nil) }
   before { allow(G5::UserExporter).to receive(:new).and_return(user_exporter) }
 
-  before { ENV['G5_AUTH_CLIENT_ID'] = default_client_id }
+  let!(:old_client_id) { ENV['G5_AUTH_CLIENT_ID'] }
   let(:default_client_id) { 'default_client_id' }
+  before { ENV['G5_AUTH_CLIENT_ID'] = default_client_id }
+  after { ENV['G5_AUTH_CLIENT_ID'] = old_client_id }
 
-  before { ENV['G5_AUTH_CLIENT_SECRET'] = default_client_secret }
+  let!(:old_client_secret) { ENV['G5_AUTH_CLIENT_SECRET'] }
   let(:default_client_secret) { 'default_client_secret' }
+  before { ENV['G5_AUTH_CLIENT_SECRET'] = default_client_secret }
+  after { ENV['G5_AUTH_CLIENT_SECRET'] = old_client_secret }
 
-  before { ENV['G5_AUTH_REDIRECT_URI'] = default_redirect_uri }
+  let!(:old_redirect_uri) { ENV['G5_AUTH_REDIRECT_URI'] }
   let(:default_redirect_uri) { 'http://test.host/default' }
+  before { ENV['G5_AUTH_REDIRECT_URI'] = default_redirect_uri }
+  after { ENV['G5_AUTH_REDIRECT_URI'] = old_redirect_uri }
 
-  before { ENV['G5_AUTH_ENDPOINT'] = default_endpoint }
+  let!(:old_endpoint) { ENV['G5_AUTH_ENDPOINT'] }
   let(:default_endpoint) { 'https://my.g5auth.host' }
+  before { ENV['G5_AUTH_ENDPOINT'] = default_endpoint }
+  after { ENV['G5_AUTH_ENDPOINT'] = old_endpoint }
 
-  before { ENV['G5_AUTH_AUTHORIZATION_CODE'] = default_auth_code }
+  let!(:old_auth_code) { ENV['G5_AUTH_AUTHORIZATION_CODE'] }
   let(:default_auth_code) { 'default_auth_code' }
+  before { ENV['G5_AUTH_AUTHORIZATION_CODE'] = default_auth_code }
+  after { ENV['G5_AUTH_AUTHORIZATION_CODE'] = old_auth_code }
 
   def expect_init_user_exporter_with(option_name, expected_value)
     expect(G5::UserExporter).to receive(:new) do |args|


### PR DESCRIPTION
When strict token validation is enabled, every time the user is fetched from the session (on every request after initial authentication), the associated access token will be validated against the auth server.

This incurs the performance penalty of an additional HTTP call on every request, so it is disabled by default. However, the only alternative to support single sign-out involved altering the session management implementation, which seemed overly risky at this time.