### PR TITLE
Devise Version pined to latest stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.2.3 (2015-06-01)
+* Pins version of devise to 3.5.1 due - https://github.com/plataformatec/devise/issues/3705
+* Pins version of omniauth-g5 to v0.3.1 due - https://github.com/G5/omniauth-g5/pull/10
+
 ## v0.2.1 (2015-05-28)
 
 * Fixes for compatibility with
@@ -21,7 +25,7 @@
 
 ## v0.1.1 (2014-07-31)
 
-* Find a user by email when a duplicate email exception is returned from 
+* Find a user by email when a duplicate email exception is returned from
   user creation.
 
 ## v0.1.0 (2014-03-12)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.2.3 (2015-06-01)
+## v0.2.3 (2015-11-30)
 * Pins version of devise to 3.5.1 due - https://github.com/plataformatec/devise/issues/3705
 * Pins version of omniauth-g5 to v0.3.1 due - https://github.com/G5/omniauth-g5/pull/10
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Devise G5 Authenticatable
 
 Devise G5 Authenticatable extends devise to provide an
-[OAuth 2.0](http://oauth.net/2)-based authentication strategy and remote 
+[OAuth 2.0](http://oauth.net/2)-based authentication strategy and remote
 credential management via the G5 Auth service.
 
 Devise G5 Authenticatable is intended as a drop-in replacement for the
@@ -10,7 +10,7 @@ G5 users.
 
 ## Current Version
 
-0.2.1
+0.2.3
 
 ## Requirements
 

--- a/devise_g5_authenticatable.gemspec
+++ b/devise_g5_authenticatable.gemspec
@@ -18,7 +18,12 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'devise', '~> 3.5'
+  # Pinned to version 3.5.1 due https://github.com/plataformatec/devise/issues/3705
+  # "`FailureApp`s `script_name: nil` breaks route generation within mounted engines #3705"
+  spec.add_dependency 'devise', '= 3.5.1'
   spec.add_dependency 'g5_authentication_client', '~> 0.5'
-  spec.add_dependency 'omniauth-g5', '~> 0.3'
+
+  # Pinned to version 0.3.1 due https://github.com/G5/omniauth-g5/pull/10
+  # Omniauth-auth2 removed 'callback_url' which broke our auth workflow
+  spec.add_dependency 'omniauth-g5', '= 0.3.1'
 end

--- a/lib/devise_g5_authenticatable/version.rb
+++ b/lib/devise_g5_authenticatable/version.rb
@@ -1,3 +1,3 @@
 module DeviseG5Authenticatable
-  VERSION = '0.2.2'
+  VERSION = '0.2.3'
 end


### PR DESCRIPTION
- Version 3.5.2 includes a bug that causes g5_authenticatable tests to break upon login in

[Fixes #107063598]